### PR TITLE
feat: add nix flake

### DIFF
--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -1,0 +1,43 @@
+name: Nix
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  Check:
+    # multi platform checks aren't really needed here;
+    # this is mainly to debug evaluation errors
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@v9
+
+      - name: Setup Nix Cache
+        uses: DeterminateSystems/magic-nix-cache-action@v2
+
+      - name: Run Check
+        run: nix flake check -L --accept-flake-config --show-trace
+
+  Build:
+    strategy:
+      matrix:
+        os: [macos-latest, ubuntu-latest]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@v9
+
+      - name: Setup Nix Cache
+        uses: DeterminateSystems/magic-nix-cache-action@v2
+
+      - name: Run Build
+        run: nix build -L --accept-flake-config --fallback

--- a/.github/workflows/update-flake.yml
+++ b/.github/workflows/update-flake.yml
@@ -1,0 +1,29 @@
+name: Update flake.lock
+
+on:
+  schedule:
+    # run every saturday
+    - cron: "0 0 * * 6"
+  workflow_dispatch:
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Nix
+        uses: nixbuild/nix-quick-install-action@v26
+
+      - name: Update lockfile & make PR
+        uses: DeterminateSystems/update-flake-lock@v20
+        id: update
+        with:
+          commit-msg: "flake: update inputs"
+          pr-title: "flake: update inputs"
+          token: ${{ github.token }}

--- a/.gitignore
+++ b/.gitignore
@@ -112,3 +112,9 @@ fabric.properties
 
 theseus.iml
 
+# nix build results
+result*
+repl-result-out*
+
+# nix dev shell
+.direnv

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,26 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1706173671,
+        "narHash": "sha256-lciR7kQUK2FCAYuszyd7zyRRmTaXVeoZsCyK6QFpGdk=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "4fddc9be4eaf195d631333908f2a454b03628ee5",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixpkgs-unstable",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,101 @@
+{
+  description = "Modrinth's game launcher";
+
+  inputs.nixpkgs.url = "nixpkgs/nixpkgs-unstable";
+
+  outputs = {
+    nixpkgs,
+    self,
+    ...
+  }: let
+    systems = [
+      "x86_64-linux"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "aarch64-darwin"
+    ];
+
+    forSystem = system: fn:
+      fn (import nixpkgs {
+        inherit system;
+        config.allowUnfree = true;
+      });
+
+    forAllSystems = fn: nixpkgs.lib.genAttrs systems (system: forSystem system fn);
+  in {
+    checks = forAllSystems ({
+      pkgs,
+      lib,
+      ...
+    }: {
+      rustfmt =
+        pkgs.runCommand "check-rustfmt" {
+          nativeBuildInputs = with pkgs; [cargo rustfmt];
+        } ''
+          cd ${./.}
+          cargo fmt -- --check
+          touch $out
+        '';
+
+      alejandra = pkgs.runCommand "check-alejandra" {} ''
+        ${lib.getExe pkgs.alejandra} --check ${./.}
+        touch $out
+      '';
+    });
+
+    devShells = forAllSystems (pkgs: {
+      default = pkgs.mkShell {
+        packages = with pkgs; [
+          # base toolchain
+          cargo
+          rustc
+
+          # toolchain utils
+          clippy
+          rustfmt
+          rust-analyzer
+
+          # nix utils
+          self.formatter.${pkgs.system}
+          nil
+        ];
+
+        RUST_SRC_PATH = "${pkgs.rust.packages.stable.rustPlatform.rustLibSrc}";
+      };
+    });
+
+    formatter = forAllSystems (pkgs: pkgs.alejandra);
+
+    overlays.default = final: prev: {
+      modrinth-app-unwrapped = prev.callPackage ./nix {
+        version = builtins.substring 0 7 self.rev or "dirty";
+
+        inherit
+          (final.darwin.apple_sdk.frameworks)
+          AppKit
+          CoreServices
+          Security
+          WebKit
+          ;
+
+        inherit (final.nodePackages) pnpm;
+      };
+
+      modrinth-app = prev.callPackage ./nix/wrapper.nix {
+        inherit (final) modrinth-app-unwrapped;
+      };
+    };
+
+    packages = forAllSystems (pkgs: let
+      pkgs' = self.overlays.default (pkgs // pkgs') pkgs;
+    in {
+      inherit
+        (pkgs')
+        modrinth-app-unwrapped
+        modrinth-app
+        ;
+
+      default = pkgs'.modrinth-app;
+    });
+  };
+}

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,0 +1,163 @@
+{
+  lib,
+  version,
+  stdenv,
+  stdenvNoCC,
+  fetchFromGitHub,
+  rustPlatform,
+  buildGoModule,
+  makeDesktopItem,
+  copyDesktopItems,
+  AppKit,
+  CoreServices,
+  Security,
+  WebKit,
+  cacert,
+  pnpm,
+  esbuild,
+  dbus,
+  freetype,
+  gtk3,
+  jq,
+  libappindicator-gtk3,
+  librsvg,
+  libsoup,
+  moreutils,
+  openssl,
+  pkg-config,
+  webkitgtk,
+}:
+rustPlatform.buildRustPackage rec {
+  pname = "modrinth-app-unwrapped";
+  inherit version;
+
+  src = lib.cleanSource ../.;
+
+  cargoLock = {
+    lockFile = ../Cargo.lock;
+    allowBuiltinFetchGit = true;
+  };
+
+  pnpm-deps = stdenvNoCC.mkDerivation {
+    pname = "${pname}-pnpm-deps";
+    inherit src version;
+
+    nativeBuildInputs = [
+      cacert
+      jq
+      moreutils
+      pnpm
+    ];
+
+    # https://github.com/NixOS/nixpkgs/blob/763e59ffedb5c25774387bf99bc725df5df82d10/pkgs/applications/misc/pot/default.nix#L56
+    installPhase = ''
+      export HOME=$(mktemp -d)
+
+      cd theseus_gui
+      pnpm config set store-dir $out
+      pnpm install --frozen-lockfile --no-optional --ignore-script
+
+      rm -rf $out/v3/tmp
+      for f in $(find $out -name "*.json"); do
+        sed -i -E -e 's/"checkedAt":[0-9]+,//g' $f
+        jq --sort-keys . $f | sponge $f
+      done
+    '';
+
+    dontFixup = true;
+    outputHashMode = "recursive";
+    outputHash = "sha256-gRQfWrAY/2XxiVSHtQd4YKruJWjkpAB5OsXZMmV0iDs=";
+  };
+
+  buildInputs =
+    [openssl]
+    ++ lib.optionals stdenv.isLinux [
+      dbus
+      freetype
+      gtk3
+      libappindicator-gtk3
+      librsvg
+      libsoup
+      webkitgtk
+    ]
+    ++ lib.optionals stdenv.isDarwin [
+      AppKit
+      CoreServices
+      Security
+      WebKit
+    ];
+
+  nativeBuildInputs = [
+    pkg-config
+    pnpm
+    copyDesktopItems
+  ];
+
+  ESBUILD_BINARY_PATH = lib.getExe (
+    esbuild.override {
+      buildGoModule = args:
+        buildGoModule (args
+          // rec {
+            version = "0.17.19";
+            src = fetchFromGitHub {
+              owner = "evanw";
+              repo = "esbuild";
+              rev = "v${version}";
+              hash = "sha256-PLC7OJLSOiDq4OjvrdfCawZPfbfuZix4Waopzrj8qsU=";
+            };
+            vendorHash = "sha256-+BfxCyg0KkDQpHt/wycy/8CTG6YBA/VJvJFhhzUnSiQ=";
+          });
+    }
+  );
+
+  preBuild = ''
+    export HOME=$(mktemp -d)
+    export STORE_PATH=$(mktemp -d)
+    pushd theseus_gui
+
+    cp -r ${pnpm-deps}/* "$STORE_PATH"
+    chmod -R +w "$STORE_PATH"
+
+    pnpm config set store-dir "$STORE_PATH"
+    pnpm install --offline --frozen-lockfile --no-optional --ignore-script
+    pnpm build
+
+    popd
+  '';
+
+  desktopItems = [
+    (makeDesktopItem rec {
+      name = "com.modrinth.ModrinthApp";
+      exec = "theseus_gui";
+      icon = "com.modrinth.ModrinthApp";
+      desktopName = "Modrinth App";
+      genericName = desktopName;
+      comment = meta.description;
+      terminal = false;
+      startupNotify = true;
+      startupWMClass = "ModrinthApp";
+      categories = ["Game" "ActionGame" "AdventureGame" "Simulation"];
+      keywords = ["game" "minecraft" "mc"];
+    })
+  ];
+
+  postInstall = lib.optionalString stdenv.isLinux ''
+    mkdir -p $out/share/{applications,icons/hicolor/256x256/apps}
+    copyDesktopItems
+    cp theseus_gui/src-tauri/icons/Square284x284Logo.png $out/share/icons/hicolor/256x256/apps/com.modrinth.ModrinthApp.png
+  '';
+
+  meta = with lib; {
+    mainProgram = "theseus_gui";
+    description = "Modrinth's game launcher";
+    longDescription = ''
+      Modrinth's game launcher which can be used as a CLI, GUI, and a library for creating and playing Modrinth projects.
+    '';
+    homepage = "https://modrinth.com";
+    license = with licenses; [gpl3Plus unfreeRedistributable];
+    maintainers = with maintainers; [getchoo];
+    platforms = with platforms; linux ++ darwin;
+    # this builds on aarch64, but the launcher itself does not support it yet
+    broken = stdenv.isAarch64;
+  };
+}

--- a/nix/wrapper.nix
+++ b/nix/wrapper.nix
@@ -1,0 +1,63 @@
+{
+  lib,
+  stdenv,
+  symlinkJoin,
+  modrinth-app-unwrapped,
+  wrapGAppsHook,
+  addOpenGLRunpath,
+  flite,
+  glib-networking,
+  jdk8,
+  jdk17,
+  jdks ? [jdk8 jdk17],
+  libGL,
+  libpulseaudio,
+  udev,
+  xorg,
+}:
+symlinkJoin {
+  name = "modrinth-app-${modrinth-app-unwrapped.version}";
+
+  paths = [modrinth-app-unwrapped];
+
+  buildInputs = [
+    glib-networking
+  ];
+
+  nativeBuildInputs = [
+    wrapGAppsHook
+  ];
+
+  postBuild = let
+    libPath = lib.makeLibraryPath [
+      flite # narrator support
+      libGL
+      libpulseaudio
+      stdenv.cc.cc.lib
+
+      udev # oshi
+
+      # lwjgl
+      xorg.libX11
+      xorg.libXcursor
+      xorg.libXext
+      xorg.libXxf86vm
+      xorg.libXrandr
+    ];
+
+    args =
+      ["--prefix PATH : ${lib.makeSearchPath "bin/java" jdks}"]
+      ++ lib.optionals stdenv.isLinux [
+        "--set LD_LIBRARY_PATH ${addOpenGLRunpath.driverLink}/lib:${libPath}"
+        "--prefix PATH : ${lib.makeBinPath [xorg.xrandr]}"
+      ];
+  in ''
+    gappsWrapperArgs+=(
+      ${lib.concatLines args}
+    )
+
+    wrapGAppsHook
+  '';
+
+  inherit (modrinth-app-unwrapped) meta;
+}


### PR DESCRIPTION
like the title says, this adds a nix flake which includes a dev shell and packages for both macos and linux! this should provide an easy way to install the app on both platforms, a stable interface for reproducible builds across the board, and easier onboarding for contributing through simple development environments. i've tested it on both systems and it works great :)

part of #497. the expression i based this on can be found [here](https://github.com/getchoo/nix-exprs) in `pkgs/modrinth-app`
