### PR TITLE
Home page fixes

### DIFF
--- a/theseus_gui/src/components/ui/Instance.vue
+++ b/theseus_gui/src/components/ui/Instance.vue
@@ -246,6 +246,7 @@ onUnmounted(() => unlisten())
 <style lang="scss" scoped>
 .instance {
   position: relative;
+  border-radius: var(--radius-lg);
 
   &:hover {
     .cta {

--- a/theseus_gui/src/components/ui/ProjectCard.vue
+++ b/theseus_gui/src/components/ui/ProjectCard.vue
@@ -12,14 +12,12 @@ import {
 import { computed, ref } from 'vue'
 import dayjs from 'dayjs'
 import relativeTime from 'dayjs/plugin/relativeTime'
-import { useRouter } from 'vue-router'
 import { useFetch } from '@/helpers/fetch.js'
 import { list } from '@/helpers/profile.js'
 import { handleError } from '@/store/notifications.js'
 import { install as pack_install } from '@/helpers/pack.js'
 dayjs.extend(relativeTime)
 
-const router = useRouter()
 const installing = ref(false)
 
 const props = defineProps({
@@ -111,7 +109,7 @@ const install = async (e) => {
 
 <template>
   <div class="wrapper">
-    <Card class="project-card button-base" @click="router.push(`/project/${project.slug}`)">
+    <Card class="project-card button-base" @click="$router.push(`/project/${project.slug}/`)">
       <div
         class="banner"
         :style="{

--- a/theseus_gui/src/components/ui/ProjectCard.vue
+++ b/theseus_gui/src/components/ui/ProjectCard.vue
@@ -12,12 +12,14 @@ import {
 import { computed, ref } from 'vue'
 import dayjs from 'dayjs'
 import relativeTime from 'dayjs/plugin/relativeTime'
+import { useRouter } from 'vue-router'
 import { useFetch } from '@/helpers/fetch.js'
 import { list } from '@/helpers/profile.js'
 import { handleError } from '@/store/notifications.js'
 import { install as pack_install } from '@/helpers/pack.js'
 dayjs.extend(relativeTime)
 
+const router = useRouter()
 const installing = ref(false)
 
 const props = defineProps({
@@ -109,7 +111,7 @@ const install = async (e) => {
 
 <template>
   <div class="wrapper">
-    <Card class="project-card button-base" @click="$router.push(`/project/${project.slug}/`)">
+    <Card class="project-card button-base" @click="router.push(`/project/${project.slug}/`)">
       <div
         class="banner"
         :style="{

--- a/theseus_gui/src/components/ui/ProjectCard.vue
+++ b/theseus_gui/src/components/ui/ProjectCard.vue
@@ -168,6 +168,7 @@ const install = async (e) => {
 .wrapper {
   position: relative;
   aspect-ratio: 1;
+  border-radius: var(--radius-lg);
 
   &:hover {
     .install:enabled {


### PR DESCRIPTION
Fixes underline on description tab not showing up when projects are opened from the homepage as outlined in #649. 

Also makes it so that the play or install button on cards doesn't show up if the mouse is over the corners of cards in the area removed by border radius, so it now only shows up if the mouse is over the area that is actually shown. 

closes #649 