### PR TITLE
Adds a "Show per page" dropdown for mods page

### DIFF
--- a/theseus_gui/src/pages/instance/Mods.vue
+++ b/theseus_gui/src/pages/instance/Mods.vue
@@ -56,11 +56,24 @@
         <span class="no-wrap"> Add from file </span>
       </template>
     </DropdownButton>
+    <br>
+    <div class="inline-option">
+          <span>Show per page</span>
+          <DropdownSelect
+            v-model="maxResults"
+            name="Max results"
+            :options="[5, 10, 15, 20, 50, 100]"
+            :default-value="maxResults"
+            :model-value="maxResults"
+            class="limit-dropdown"
+            @change="updateMaxPagination"
+          />
+        </div>
   </Card>
   <Pagination
     v-if="projects.length > 0"
     :page="currentPage"
-    :count="Math.ceil(search.length / 20)"
+    :count="Math.ceil(search.length / maxResults)"
     class="pagination-before"
     :link-function="(page) => `?page=${page}`"
     @switch-page="switchPage"
@@ -198,7 +211,7 @@
         </section>
       </div>
       <div
-        v-for="mod in search.slice((currentPage - 1) * 20, currentPage * 20)"
+        v-for="mod in search.slice((currentPage - 1) * maxResults, currentPage * maxResults)"
         :key="mod.file_name"
         class="table-row"
         @contextmenu.prevent.stop="(c) => handleRightClick(c, mod)"
@@ -519,6 +532,7 @@ const shareModal = ref(null)
 const ascending = ref(true)
 const sortColumn = ref('Name')
 const currentPage = ref(1)
+const maxResults = ref(20)
 
 const selected = computed(() =>
   Array.from(selectionMap.value)
@@ -835,6 +849,13 @@ const updateModpack = async () => {
   updatingModpack.value = false
 }
 
+const updateMaxPagination = async () => {
+  const max = Math.ceil(search.value.length / maxResults.value)
+  if (currentPage.value > max) {
+    currentPage.value = max
+  }
+}
+
 watch(selectAll, () => {
   for (const [key, value] of Array.from(selectionMap.value)) {
     if (value !== selectAll.value) {
@@ -941,6 +962,22 @@ onUnmounted(() => {
 
   .btn {
     height: 2.5rem;
+  }
+
+  .inline-option {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: 0.5rem;
+    // width: 100%;
+
+    .sort-dropdown {
+      max-width: 12.25rem;
+    }
+
+    .limit-dropdown {
+      width: 5rem;
+    }
   }
 
   .dropdown-input {

--- a/theseus_gui/src/pages/instance/Mods.vue
+++ b/theseus_gui/src/pages/instance/Mods.vue
@@ -56,13 +56,12 @@
         <span class="no-wrap"> Add from file </span>
       </template>
     </DropdownButton>
-    <br>
     <div class="inline-option">
           <span>Show per page</span>
           <DropdownSelect
             v-model="maxResults"
             name="Max results"
-            :options="[5, 10, 15, 20, 50, 100]"
+            :options="dropdownPageOptions"
             :default-value="maxResults"
             :model-value="maxResults"
             class="limit-dropdown"
@@ -532,7 +531,7 @@ const shareModal = ref(null)
 const ascending = ref(true)
 const sortColumn = ref('Name')
 const currentPage = ref(1)
-const maxResults = ref(20)
+
 
 const selected = computed(() =>
   Array.from(selectionMap.value)
@@ -622,6 +621,24 @@ const updateSort = (projects) => {
       })
   }
 }
+
+const maxResults = ref(search.value.length < 20 ? search.value.length : 20);
+
+const dropdownPageOptions = computed(() => {
+  const baseOptions = [5, 10, 15, 20, 50, 100];
+  return [
+    ...baseOptions.filter(option => option <= search.value.length),
+    search.value.length
+  ];
+});
+
+watch(search, (newSearch) => {
+  if (newSearch.length < maxResults.value) {
+    maxResults.value = newSearch.length;
+  } else {
+    maxResults.value = 20;
+  }
+})
 
 const sortProjects = (filter) => {
   if (sortColumn.value === filter) {

--- a/theseus_gui/src/store/pagination.js
+++ b/theseus_gui/src/store/pagination.js
@@ -1,0 +1,16 @@
+import { defineStore } from 'pinia'
+
+export const usePagination = defineStore('paginationStore', {
+  state: () => ({
+    maxResults: 20,
+    paginationState: 20,
+  }),
+  actions: {
+    setMaxResults(newMaxResults) {
+        this.maxResults = newMaxResults;
+    },
+    setPagination(newPaginationState) {
+        this.paginationState = newPaginationState;
+    },
+  },
+})


### PR DESCRIPTION
Closes #692

![image](https://github.com/modrinth/theseus/assets/20671184/77c4d952-3459-4907-8181-6a7083f20ed7)

Adds a "Show per page" dropdown similar to that in the browse menu. Defaults to 20 as previously, but maxes out to the entire modlist if the user wants all their mods on a single page. Also supports values below optional values

![image](https://github.com/modrinth/theseus/assets/20671184/1434ab2e-d837-4456-89cd-7be889331aa5)

I left a comment on the css which would push the page count to the next line, but kept it commented to keep the behavior the same as on the browse page. 