### PR TITLE
fix: change ProfilePathId::from_fs_path function to return stripped path

### DIFF
--- a/theseus/src/state/profiles.rs
+++ b/theseus/src/state/profiles.rs
@@ -59,15 +59,16 @@ impl ProfilePathId {
         let profiles_dir = io::canonicalize(
             State::get().await?.directories.profiles_dir().await,
         )?;
-        path.strip_prefix(profiles_dir)
+        let path = path
+            .strip_prefix(profiles_dir)
             .ok()
-            .and_then(|p| p.file_name())
             .ok_or_else(|| {
                 crate::ErrorKind::FSError(format!(
                     "Path {path:?} does not correspond to a profile",
                     path = path
                 ))
-            })?;
+            })?
+            .into();
         Ok(Self(path))
     }
 


### PR DESCRIPTION
ProfilePathId::from_fs_path was stripping modrinths profile path from the full filesystem path, but then returning the unstripped path instead. This caused some theseus_cli commands to search for a profile using a full path instead of just the profile name.