### PR TITLE
Add a development container file

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,14 @@
+FROM mcr.microsoft.com/devcontainers/rust:1-bookworm
+
+RUN apt update && \
+    DEBIAN_FRONTEND=noninteractive apt install -y libwebkit2gtk-4.0-dev \
+    build-essential \
+    curl \
+    wget \
+    file \
+    libssl-dev \
+    libgtk-3-dev \
+    libayatana-appindicator3-dev \
+    librsvg2-dev
+
+RUN DEBIAN_FRONTEND=noninteractive apt install -y firefox-esr

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,68 @@
+{
+  "name": "Theseus",
+
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
+
+  "features": {
+    "ghcr.io/devcontainers/features/node": {
+      "version": "18"
+    },
+    "ghcr.io/devcontainers/features/desktop-lite:1": {},
+    "ghcr.io/devcontainers/features/github-cli": {}
+  },
+
+  "forwardPorts": [6080, 5901],
+
+  "portsAttributes": {
+    "6080": {
+      "label": "desktop"
+    },
+    "5901": {
+      "label": "vnc"
+    }
+  },
+
+  "onCreateCommand": ". ${NVM_DIR}/nvm.sh && nvm install 18 && nvm use 18 && corepack enable",
+
+  "updateContentCommand": "cd theseus_gui && pnpm install && pnpm build && cd .. && cargo build --bin theseus_gui",
+
+  "customizations": {
+    "vscode": {
+      "settings": {
+        "editor.formatOnSave": true,
+        "eslint.run": "onSave"
+      },
+      "extensions": [
+        // Vue Language Features (Volar) by Vue
+        // Adds support for Vue SFC and improves TypeScript inference of Vue files.
+        "Vue.volar",
+        // [REMOVED] TypeScript and JavaScript Language Features by vscode
+        // Reason: Volar implements TypeScript language server, and removal avoids conflicts between them.
+        "-vscode.typescript-language-features",
+        // ESLint by Microsoft
+        // Adds ESLint in-editor linting.
+        "dbaeumer.vscode-eslint",
+        // Prettier by Prettier
+        // Formats JavaScript, TypeScript, Vue and other supported code files.
+        "esbenp.prettier-vscode",
+        // EditorConfig for VS Code
+        // Adds support for EditorConfig file.
+        "EditorConfig.EditorConfig",
+        // JS Refactoring Assistant by P42
+        // Provides lots of useful JavaScript, TypeScript and Vue refactors.
+        "p42ai.refactor",
+        // TypeScript Explorer by mxs
+        // Allows to quickly explore TypeScript types without a hassle.
+        "mxsdev.typescript-explorer",
+        // Tauri by Tauri
+        // Adds helpful commands and config file validation for Tauri development.
+        "tauri-apps.tauri-vscode",
+        // CSS Variable Autocomplete by Vu Nguyen
+        // Helps with variables when writing CSS files.
+        "vunguyentuan.vscode-css-variables"
+      ]
+    }
+  }
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,12 +1,13 @@
 {
   "recommendations": [
-    "tauri-apps.tauri-vscode",
-    "vunguyentuan.vscode-css-variables",
-    "stylelint.vscode-stylelint",
-    "eamodio.gitlens",
+    "Vue.volar",
+    "vscode.typescript-language-features",
+    "dbaeumer.vscode-eslint",
     "esbenp.prettier-vscode",
-    "pivaszbs.svelte-autoimport",
-    "svelte.svelte-vscode",
-    "ardenivanov.svelte-intellisense"
+    "EditorConfig.EditorConfig",
+    "p42ai.refactor",
+    "mxsdev.typescript-explorer",
+    "tauri-apps.tauri-vscode",
+    "vunguyentuan.vscode-css-variables"
   ]
 }


### PR DESCRIPTION
Development containers allow to develop the project in virtualised
environment, like on desktop with Docker, or remotely with providers
like GitHub Codespaces.

This makes it extremely easy for outsiders to contribute to the project,
since the environment is already set up for them, from Rust to the full
desktop environment to test Theseus GUI. It also makes project more
accessible to contributors who don't have the best hardware to do Rust
development.
