### PR TITLE
Ignore stale search requests

### DIFF
--- a/theseus_gui/src/helpers/fetch.js
+++ b/theseus_gui/src/helpers/fetch.js
@@ -2,14 +2,19 @@ import { ofetch } from 'ofetch'
 import { handleError } from '@/store/state.js'
 import { getVersion } from '@tauri-apps/api/app'
 
-export const useFetch = async (url, item, isSilent) => {
+export const useFetch = async (url, item, isSilent, signal) => {
   try {
     const version = await getVersion()
 
     return await ofetch(url, {
       headers: { 'User-Agent': `modrinth/theseus/${version} (support@modrinth.com)` },
+      signal: signal,
     })
   } catch (err) {
+    if (err.message.startsWith('Fetch is aborted') || err.message.startsWith('Request signal is aborted')) {
+      throw err;
+    }
+
     if (!isSilent) {
       handleError({ message: `Error fetching ${item}` })
     }

--- a/theseus_gui/src/helpers/fetch.js
+++ b/theseus_gui/src/helpers/fetch.js
@@ -2,19 +2,14 @@ import { ofetch } from 'ofetch'
 import { handleError } from '@/store/state.js'
 import { getVersion } from '@tauri-apps/api/app'
 
-export const useFetch = async (url, item, isSilent, signal) => {
+export const useFetch = async (url, item, isSilent) => {
   try {
     const version = await getVersion()
 
     return await ofetch(url, {
       headers: { 'User-Agent': `modrinth/theseus/${version} (support@modrinth.com)` },
-      signal: signal,
     })
   } catch (err) {
-    if (err.message.startsWith('Fetch is aborted') || err.message.startsWith('Request signal is aborted')) {
-      throw err;
-    }
-
     if (!isSilent) {
       handleError({ message: `Error fetching ${item}` })
     }

--- a/theseus_gui/src/pages/Browse.vue
+++ b/theseus_gui/src/pages/Browse.vue
@@ -148,8 +148,6 @@ if (route.query.ai) {
   hideAlreadyInstalled.value = route.query.ai === 'true'
 }
 
-let abortController = new AbortController()
-
 async function refreshSearch() {
   const base = 'https://api.modrinth.com/v2/'
 
@@ -253,17 +251,7 @@ async function refreshSearch() {
 
   let val = `${base}${url}`
 
-
-  abortController.abort()
-  abortController = new AbortController()
-
-  let rawResults
-  try {
-    rawResults = await useFetch(val, 'search results', offline.value, abortController.signal)
-  } catch (error) {
-    return
-  }
-
+  let rawResults = await useFetch(val, 'search results', offline.value)
   if (!rawResults) {
     rawResults = {
       hits: [],

--- a/theseus_gui/src/pages/Browse.vue
+++ b/theseus_gui/src/pages/Browse.vue
@@ -148,7 +148,13 @@ if (route.query.ai) {
   hideAlreadyInstalled.value = route.query.ai === 'true'
 }
 
+let currentSearch = 0;
+let latestFinishedSearch = 0;
+
 async function refreshSearch() {
+  currentSearch += 1;
+  const thisSearch = currentSearch;
+
   const base = 'https://api.modrinth.com/v2/'
 
   const params = [`limit=${maxResults.value}`, `index=${sortType.value.name}`]
@@ -252,6 +258,12 @@ async function refreshSearch() {
   let val = `${base}${url}`
 
   let rawResults = await useFetch(val, 'search results', offline.value)
+
+  if (thisSearch < latestFinishedSearch) {
+    return
+  }
+  latestFinishedSearch = thisSearch
+
   if (!rawResults) {
     rawResults = {
       hits: [],

--- a/theseus_gui/src/pages/Browse.vue
+++ b/theseus_gui/src/pages/Browse.vue
@@ -148,6 +148,8 @@ if (route.query.ai) {
   hideAlreadyInstalled.value = route.query.ai === 'true'
 }
 
+let abortController = new AbortController()
+
 async function refreshSearch() {
   const base = 'https://api.modrinth.com/v2/'
 
@@ -251,7 +253,17 @@ async function refreshSearch() {
 
   let val = `${base}${url}`
 
-  let rawResults = await useFetch(val, 'search results', offline.value)
+
+  abortController.abort()
+  abortController = new AbortController()
+
+  let rawResults
+  try {
+    rawResults = await useFetch(val, 'search results', offline.value, abortController.signal)
+  } catch (error) {
+    return
+  }
+
   if (!rawResults) {
     rawResults = {
       hits: [],


### PR DESCRIPTION
When typing multiple characters into the search bar, and the earlier request completes after the new one, theseus will display stale data.

https://github.com/modrinth/theseus/assets/22177966/9a9ff412-27f6-4466-9b9a-037fc4566f10


I first fixed this by cancelling requests when a new search was triggered https://github.com/modrinth/theseus/commit/0ee36987e280871330ad75475959192256a5911d, but that had the disadvantage that results are only shown after the user fully finished searching (assuming time between keystrokes < duration of request).
Instead I keep track of the current search idx and ignore outdated results coming in later.


Alternatively (additionally?) the search input could be throttled to limit load on the server and reduce the likelihood of requests resolving out of order (I just found [`useThrottleFn`](https://vueuse.org/shared/useThrottleFn/) which looks easy to use).