### PR TITLE
fix(gui/library): fix sort/group by game version

### DIFF
--- a/theseus_gui/src/components/GridDisplay.vue
+++ b/theseus_gui/src/components/GridDisplay.vue
@@ -141,7 +141,11 @@ const filteredResults = computed(() => {
 
   if (sortBy.value === 'Game version') {
     instances.sort((a, b) => {
-      return a.metadata.game_version.localeCompare(b.metadata.game_version)
+      return a.metadata.game_version.localeCompare(
+        b.metadata.game_version,
+        undefined,
+        { numeric: true }
+      )
     })
   }
 
@@ -227,6 +231,18 @@ const filteredResults = computed(() => {
     sortedEntries.forEach((entry) => {
       instanceMap.set(entry[0], entry[1])
     })
+  }
+  // default sorting would do 1.20.4 < 1.8.9 because 2 < 8
+  // localeCompare with numeric=true puts 1.8.9 < 1.20.4 because 8 < 20
+  if (group.value === 'Game version') {
+    const sortedEntries = [...instanceMap.entries()].sort((a, b) => {
+      return a[0].localeCompare(b[0], undefined, { numeric: true })
+    })
+    instanceMap.clear()
+    sortedEntries.forEach((entry) => {
+      instanceMap.set(entry[0], entry[1])
+    })
+
   }
 
   return instanceMap


### PR DESCRIPTION
In the Library, game version 1.8.9 is sorted/grouped after 1.20 because the default sorting sorts 2 < 8
therefore localeCompare(with numeric=true) is needed, it detects 8 < 20 and puts the versions in the correct order.
