### PR TITLE
change app category to 'Game'

### DIFF
--- a/theseus_gui/src-tauri/tauri.conf.json
+++ b/theseus_gui/src-tauri/tauri.conf.json
@@ -49,7 +49,7 @@
     "macOSPrivateApi": true,
     "bundle": {
       "active": true,
-      "category": "Entertainment",
+      "category": "Game",
       "copyright": "",
       "deb": {
         "depends": []


### PR DESCRIPTION
As of now, the Modrinth launcher is listed in the category 'Internet' (alongside Firefox and Chrome), and not in 'Games'.
I’m on KDE Plasma, but since it’s labeled as 'Internet' in `modrinth-app.desktop` I assume this happens on every Linux.
This PR *changes* 'Entertainment' to 'Game'. I don’t know if the 'Entertainment' is needed for MacOS or Windows.
