### PR TITLE
feat: improve sorting for mods in instances

### DIFF
--- a/theseus_gui/src/pages/instance/Mods.vue
+++ b/theseus_gui/src/pages/instance/Mods.vue
@@ -592,23 +592,14 @@ const updateSort = (projects) => {
   switch (sortColumn.value) {
     case 'Version':
       return projects.slice().sort((a, b) => {
-        if (a.version < b.version) {
-          return ascending.value ? -1 : 1
+        let aVersion = a.version ? a.version : ''
+        let bVersion = b.version ? b.version : ''
+
+        if (ascending.value) {
+          return aVersion.localeCompare(bVersion, undefined, { numeric: true })
+        } else {
+          return bVersion.localeCompare(aVersion, undefined, { numeric: true })
         }
-        if (a.version > b.version) {
-          return ascending.value ? 1 : -1
-        }
-        return 0
-      })
-    case 'Author':
-      return projects.slice().sort((a, b) => {
-        if (a.author < b.author) {
-          return ascending.value ? -1 : 1
-        }
-        if (a.author > b.author) {
-          return ascending.value ? 1 : -1
-        }
-        return 0
       })
     case 'Enabled':
       return projects.slice().sort((a, b) => {
@@ -622,13 +613,11 @@ const updateSort = (projects) => {
       })
     default:
       return projects.slice().sort((a, b) => {
-        if (a.name < b.name) {
-          return ascending.value ? -1 : 1
+        if (ascending.value) {
+          return a.name.localeCompare(b.name)
+        } else {
+          return b.name.localeCompare(a.name)
         }
-        if (a.name > b.name) {
-          return ascending.value ? 1 : -1
-        }
-        return 0
       })
   }
 }
@@ -1131,6 +1120,7 @@ onUnmounted(() => {
     }
   }
 }
+
 .empty-prompt {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
This PR improves the sorting behavior for mods inside of an instance. 

name sorting now sorts by logical character and not by ASCII code so uppercase letters do not strictly appear before lowercase ones.
version sorting now respects numbers like in #1025  
also removed the Author sorting since it wasn't used anywhere