### PR TITLE
fix: implement actions for context menu in instance mod list

### DIFF
--- a/theseus_gui/src/pages/instance/Index.vue
+++ b/theseus_gui/src/pages/instance/Index.vue
@@ -102,17 +102,6 @@
     <template #open_folder> <ClipboardCopyIcon /> Open Folder </template>
     <template #copy_link> <ClipboardCopyIcon /> Copy Link </template>
     <template #open_link> <ClipboardCopyIcon /> Open In Modrinth <ExternalIcon /> </template>
-    <template #copy_names><EditIcon />Copy names</template>
-    <template #copy_slugs><HashIcon />Copy slugs</template>
-    <template #copy_links><GlobeIcon />Copy Links</template>
-    <template #toggle><EditIcon />Toggle selected</template>
-    <template #disable><XIcon />Disable selected</template>
-    <template #enable><CheckCircleIcon />Enable selected</template>
-    <template #hide_show><EyeIcon />Show/Hide unselected</template>
-    <template #update_all
-      ><UpdatedIcon />Update {{ selected.length > 0 ? 'selected' : 'all' }}</template
-    >
-    <template #filter_update><UpdatedIcon />Select Updatable</template>
   </ContextMenu>
 </template>
 <script setup>
@@ -131,12 +120,6 @@ import {
   ClipboardCopyIcon,
   PlusIcon,
   ExternalIcon,
-  HashIcon,
-  GlobeIcon,
-  EyeIcon,
-  XIcon,
-  CheckCircleIcon,
-  UpdatedIcon,
 } from 'omorphia'
 import { get, run } from '@/helpers/profile'
 import {
@@ -287,6 +270,18 @@ const handleOptionsClick = async (args) => {
       break
     case 'copy_path':
       await navigator.clipboard.writeText(instance.value.path)
+      break
+    case 'open_link':
+      window.__TAURI_INVOKE__('tauri', {
+        __tauriModule: 'Shell',
+        message: {
+          cmd: 'open',
+          path: args.item.link,
+        },
+      })
+      break
+    case 'copy_link':
+      await navigator.clipboard.writeText(args.item.link)
       break
   }
 }


### PR DESCRIPTION
This PR implements the `open in Modrinth` and `copy lint` for the contextMenu that opens when right-clicking in on a mod in the instance list. 

![image](https://github.com/modrinth/theseus/assets/81473300/a841a42c-dae5-4ffb-80cb-69af14b5b367)

I also removed some seemingly unused actions.
