### PR TITLE
fix: remove white flash when starting app

### DIFF
--- a/theseus_gui/src-tauri/src/main.rs
+++ b/theseus_gui/src-tauri/src/main.rs
@@ -29,6 +29,12 @@ fn is_dev() -> bool {
     cfg!(debug_assertions)
 }
 
+/// Show Main Window - called once after first frontend rendered
+#[tauri::command]
+fn show_window(window: tauri::Window) {
+    window.get_window("main").unwrap().show().unwrap();
+}
+
 // Toggles decorations
 #[tauri::command]
 async fn toggle_decorations(b: bool, window: tauri::Window) -> api::Result<()> {
@@ -92,6 +98,8 @@ fn main() {
             }
 
             let win = app.get_window("main").unwrap();
+            win.hide().unwrap();
+
             #[cfg(not(target_os = "linux"))]
             {
                 use window_shadows::set_shadow;
@@ -110,9 +118,6 @@ fn main() {
                 })
                 .unwrap();
             }
-
-            // Show app now that we are setup
-            win.show().unwrap();
 
             Ok(())
         });
@@ -146,6 +151,7 @@ fn main() {
             initialize_state,
             is_dev,
             toggle_decorations,
+            show_window,
             api::auth::auth_login,
         ]);
 

--- a/theseus_gui/src/App.vue
+++ b/theseus_gui/src/App.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { computed, ref, watch } from 'vue'
+import { computed, onMounted, ref, watch } from 'vue'
 import { RouterView, RouterLink, useRouter, useRoute } from 'vue-router'
 import {
   HomeIcon,
@@ -27,7 +27,7 @@ import { offline_listener, command_listener, warning_listener } from '@/helpers/
 import { MinimizeIcon, MaximizeIcon, ChatIcon } from '@/assets/icons'
 import { type } from '@tauri-apps/api/os'
 import { appWindow } from '@tauri-apps/api/window'
-import { isDev, getOS, isOffline, showLauncherLogsFolder } from '@/helpers/utils.js'
+import { isDev, getOS, isOffline, showLauncherLogsFolder, showMainWindow } from '@/helpers/utils.js'
 import {
   mixpanel_track,
   mixpanel_init,
@@ -60,7 +60,6 @@ const os = ref('')
 
 defineExpose({
   initialize: async () => {
-    isLoading.value = false
     const {
       native_decorations,
       theme,
@@ -112,12 +111,18 @@ defineExpose({
     if (showOnboarding.value) {
       onboardingVideo.value.play()
     }
+
+    isLoading.value = false
   },
   failure: async (e) => {
     isLoading.value = false
     failureText.value = e
     os.value = await getOS()
   },
+})
+
+onMounted(async () => {
+  await showMainWindow()
 })
 
 const confirmClose = async () => {

--- a/theseus_gui/src/helpers/utils.js
+++ b/theseus_gui/src/helpers/utils.js
@@ -12,6 +12,11 @@ export async function isDev() {
   return await invoke('is_dev')
 }
 
+/// Show Main Window - called once after first frontend rendered
+export async function showMainWindow() {
+  return await invoke('show_window')
+}
+
 // One of 'Windows', 'Linux', 'MacOS'
 export async function getOS() {
   return await invoke('plugin:utils|get_os')


### PR DESCRIPTION
This PR should remove all the white flashes happening when starting the app. Not sure if they happened on all platforms but at least on Linux - Wayland they did.

The app only gets shown after the first render happened. This was kinda already done but it seems like the window was shown too early and the Tauri setting didn't work (at least on linux) so I had to hide it by hand.

```jsonc
    "windows": [
      {
        "titleBarStyle": "Overlay",
        "hiddenTitle": true,
        "fullscreen": false,
        "height": 800,
        "resizable": true,
        "title": "Modrinth App",
        "width": 1280,
        "minHeight": 700,
        "minWidth": 1100,
        "visible": false, // <- this should have hidden the window already
        "decorations": false
      }
    ]
```

the second fix was moving the `isLoading.value = false` in vue after the initialization code