### PR TITLE
feat: add category filter to mods within instance

### DIFF
--- a/theseus_gui/src/components/ui/filter/CategoryFilter.vue
+++ b/theseus_gui/src/components/ui/filter/CategoryFilter.vue
@@ -5,8 +5,8 @@ import { handleError } from '@/store/notifications.js'
 import { formatCategory, formatCategoryHeader, SearchFilter } from 'omorphia'
 
 const props = defineProps({
-  projectTypes: {
-    type: Object,
+  projectType: {
+    type: String,
     required: true,
   },
   facets: {
@@ -21,24 +21,25 @@ function onToggleFacet(elementName) {
   emits('toggleFacet', elementName)
 }
 
-const projectTypes = computed(() => {
-  return props.projectTypes.map((type) => {
-    return type === 'datapack' ? 'mod' : type
-  })
-})
-
 const sortedCategories = computed(() => {
   const values = new Map()
 
-  console.log(projectTypes.value)
-  console.log('hi')
-
-  for (const category of categories.value.filter((cat) => {
-    return projectTypes.value.includes(cat.project_type)
+  outer: for (const category of categories.value.filter((cat) => {
+    return (
+      cat.project_type === (props.projectType === 'datapack' ? 'mod' : props.projectType) ||
+      props.projectType === 'all'
+    )
   })) {
     if (!values.has(category.header)) {
       values.set(category.header, [])
     }
+
+    for (let existingCategory of values.get(category.header)) {
+      if (existingCategory.name === category.name) {
+        continue outer
+      }
+    }
+
     values.get(category.header).push(category)
   }
   return values

--- a/theseus_gui/src/components/ui/filter/CategoryFilter.vue
+++ b/theseus_gui/src/components/ui/filter/CategoryFilter.vue
@@ -1,0 +1,73 @@
+<script setup>
+import { computed, ref } from 'vue'
+import { get_categories, sortByNameOrNumber } from '@/helpers/tags.js'
+import { handleError } from '@/store/notifications.js'
+import { formatCategory, formatCategoryHeader, SearchFilter } from 'omorphia'
+
+const props = defineProps({
+  projectTypes: {
+    type: Object,
+    required: true,
+  },
+  facets: {
+    type: Object,
+    required: true,
+  },
+})
+
+const emits = defineEmits(['toggleFacet'])
+
+function onToggleFacet(elementName) {
+  emits('toggleFacet', elementName)
+}
+
+const projectTypes = computed(() => {
+  return props.projectTypes.map((type) => {
+    return type === 'datapack' ? 'mod' : type
+  })
+})
+
+const sortedCategories = computed(() => {
+  const values = new Map()
+
+  console.log(projectTypes.value)
+  console.log('hi')
+
+  for (const category of categories.value.filter((cat) => {
+    return projectTypes.value.includes(cat.project_type)
+  })) {
+    if (!values.has(category.header)) {
+      values.set(category.header, [])
+    }
+    values.get(category.header).push(category)
+  }
+  return values
+})
+
+const categories = await get_categories()
+  .catch(handleError)
+  .then((s) => sortByNameOrNumber(s, ['header', 'name']))
+  .then(ref)
+</script>
+
+<template>
+  <div
+    v-for="categoryList in Array.from(sortedCategories)"
+    :key="categoryList[0]"
+    class="categories"
+  >
+    <h2>{{ formatCategoryHeader(categoryList[0]) }}</h2>
+    <div v-for="category in categoryList[1]" :key="category.name">
+      <SearchFilter
+        :active-filters="facets"
+        :icon="category.icon"
+        :display-name="formatCategory(category.name)"
+        :facet-name="`categories:${encodeURIComponent(category.name)}`"
+        class="filter-checkbox"
+        @toggle="onToggleFacet"
+      />
+    </div>
+  </div>
+</template>
+
+<style scoped lang="scss"></style>

--- a/theseus_gui/src/helpers/tags.js
+++ b/theseus_gui/src/helpers/tags.js
@@ -34,3 +34,29 @@ export async function get_donation_platforms() {
 export async function get_report_types() {
   return await invoke('plugin:tags|tags_get_report_types')
 }
+
+// Sorts alphabetically, but correctly identifies 8x, 128x, 256x, etc
+// identifier[0], then if it ties, identifier[1], etc
+export function sortByNameOrNumber(sortable, identifiers) {
+  sortable.sort((a, b) => {
+    for (let identifier of identifiers) {
+      let aNum = parseFloat(a[identifier])
+      let bNum = parseFloat(b[identifier])
+      if (isNaN(aNum) && isNaN(bNum)) {
+        // Both are strings, sort alphabetically
+        let stringComp = a[identifier].localeCompare(b[identifier])
+        if (stringComp != 0) return stringComp
+      } else if (!isNaN(aNum) && !isNaN(bNum)) {
+        // Both are numbers, sort numerically
+        let numComp = aNum - bNum
+        if (numComp != 0) return numComp
+      } else {
+        // One is a number and one is a string, numbers go first
+        let numStringComp = isNaN(aNum) ? 1 : -1
+        if (numStringComp != 0) return numStringComp
+      }
+    }
+    return 0
+  })
+  return sortable
+}

--- a/theseus_gui/src/pages/Browse.vue
+++ b/theseus_gui/src/pages/Browse.vue
@@ -605,11 +605,7 @@ onUnmounted(() => unlistenOffline())
             @update:model-value="onSearchChangeToTop(1)"
           />
         </div>
-        <CategoryFilter
-          :facets="facets"
-          :project-types="Array.of(projectType)"
-          @toggle-facet="toggleFacet"
-        />
+        <CategoryFilter :facets="facets" :project-type="projectType" @toggle-facet="toggleFacet" />
         <div v-if="projectType !== 'datapack'" class="environment">
           <h2>Environments</h2>
           <SearchFilter

--- a/theseus_gui/src/pages/instance/Index.vue
+++ b/theseus_gui/src/pages/instance/Index.vue
@@ -353,9 +353,8 @@ Button {
     background: transparent;
   }
 
-  .card {
+  :deep(.card) {
     min-height: unset;
-    margin-bottom: 0;
   }
 }
 

--- a/theseus_gui/src/pages/instance/Mods.vue
+++ b/theseus_gui/src/pages/instance/Mods.vue
@@ -364,7 +364,7 @@
     :instance="instance"
     :versions="props.versions"
   />
-  <Teleport to=".side-cards">
+  <Teleport v-if="mounted" to=".side-cards">
     <Card class="filter-panel">
       <CategoryFilter
         :facets="facets"
@@ -401,7 +401,7 @@ import {
   Pagination,
   DropdownSelect,
 } from 'omorphia'
-import { computed, onUnmounted, ref, watch } from 'vue'
+import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
 import { useRouter } from 'vue-router'
 import {
   add_project_from_path,
@@ -460,6 +460,14 @@ const canUpdatePack = computed(() => {
   return props.instance.metadata.linked_data.version_id !== props.instance.modrinth_update_version
 })
 const exportModal = ref(null)
+
+// used to make sure to only render teleport (category selector)
+// when the page is fully loading so the sidebar definitely exists
+let mounted = ref(false)
+
+onMounted(() => {
+  mounted.value = true
+})
 
 const initProjects = (initInstance) => {
   projects.value = []


### PR DESCRIPTION
This PR adds a category selector to the mod's view

![image](https://github.com/modrinth/theseus/assets/81473300/3f873ef4-71e0-45ea-ac94-d4d4aa10b08d)

this would lay the groundwork to close #1091, #1059, #875
I would add further filter options in additional PRs so this one does not get too big

currently when `all` is selected as a project type all possible categories are shown. This is kinda of a lot so maybe the category filter should only be shown when some specific project type is chosen. But I think this would kinda hide the feature and people would think that the filters don't exist.
An alternative "fix" would be to only show categories that some project uses.

note:
please remove #1091 from the PR auto-close list. since github falsely added it... 