### PR TITLE
Don’t connect to Discord IPC at all if it is disabled on launch

### DIFF
--- a/theseus/src/state/mod.rs
+++ b/theseus/src/state/mod.rs
@@ -181,7 +181,7 @@ impl State {
 
         let safety_processes = SafeProcesses::new();
 
-        let discord_rpc = DiscordGuard::init(is_offline).await?;
+        let discord_rpc = DiscordGuard::init(is_offline || settings.disable_discord_rpc).await?;
         if !settings.disable_discord_rpc && !is_offline {
             // Add default Idling to discord rich presence
             // Force add to avoid recursion


### PR DESCRIPTION
Since disabling Discord IPC is listed as a privacy setting, it would be preferable the launcher didn’t connect to Discord at all if IPC is disabled on launch.