### PR TITLE
Add profile content caching

### DIFF
--- a/theseus/src/state/dirs.rs
+++ b/theseus/src/state/dirs.rs
@@ -203,6 +203,11 @@ impl DirectoryInfo {
         self.caches_dir().join("metadata")
     }
 
+    #[inline]
+    pub fn caches_content_dir(&self) -> PathBuf {
+        self.caches_dir().join("content")
+    }
+
     /// Get path from environment variable
     #[inline]
     fn env_path(name: &str) -> Option<PathBuf> {


### PR DESCRIPTION
This caches any content file a profile downloads, saving time and bandwidth when installing the same mod version again, speeding up pack updates and re-installs. It also avoids _copying_ files by creating hard links instead.
