### PR TITLE
fix: deleting logs files

### DIFF
--- a/theseus/src/api/logs.rs
+++ b/theseus/src/api/logs.rs
@@ -296,7 +296,7 @@ pub async fn delete_logs_by_filename(
     }?;
 
     let path = logs_folder.join(filename);
-    io::remove_dir_all(&path).await?;
+    io::remove_file(&path).await?;
     Ok(())
 }
 


### PR DESCRIPTION
Currently when trying to delete logs you get a error

```
An error occurred
I/O error: Not a directory (os error 20), path: /home/tobinio/.config/com.modrinth.theseus/profiles/testing 1.20.5/logs/2024-05-21-1.log.gz
```

since it tries to remove a directory but its a file.

note:
not sure if this is a linux only problem