### PR TITLE
Fix scrolling to top problems

### DIFF
--- a/theseus_gui/src/pages/Browse.vue
+++ b/theseus_gui/src/pages/Browse.vue
@@ -897,7 +897,6 @@ onUnmounted(() => unlistenOffline())
 
 .search-container {
   display: flex;
-  height: 100%; /* takes up only the necessary height */
   overflow-y: auto;
   scroll-behavior: smooth;
 

--- a/theseus_gui/src/routes.js
+++ b/theseus_gui/src/routes.js
@@ -138,7 +138,11 @@ export default new createRouter({
   linkActiveClass: 'router-link-active',
   linkExactActiveClass: 'router-link-exact-active',
   scrollBehavior() {
-    // always scroll to top
-    return { top: 0 }
+    // Sometimes Vue's scroll behavior is not working as expected, so we need to manually scroll to top (especially on Linux)
+    document.querySelector(".router-view").scrollTop = 0;
+    return {
+      el: ".router-view",
+      top: 0
+    }
   },
 })


### PR DESCRIPTION
This PR fixes an issue where Vue's scrolling behaviour inconsistently failed to scroll to the top of the entire page on certain desktop environments or operating systems. The problem occurred because Theseus has scrolling within an inner container rather than the entire page, leading to inconsistent behaviour.